### PR TITLE
Update gbench branch name and API calls

### DIFF
--- a/cmake/Templates/GoogleBenchmark.CMakeLists.txt.cmake
+++ b/cmake/Templates/GoogleBenchmark.CMakeLists.txt.cmake
@@ -4,7 +4,7 @@ include(ExternalProject)
 
 ExternalProject_Add(GoogleBenchmark
                     GIT_REPOSITORY    https://github.com/google/benchmark.git
-                    GIT_TAG           master 
+                    GIT_TAG           v1.8.3
                     SOURCE_DIR        "${GBENCH_ROOT}/googlebenchmark"
                     BINARY_DIR        "${GBENCH_ROOT}/build"
                     INSTALL_DIR		    "${GBENCH_ROOT}/install"

--- a/event_bench.cpp
+++ b/event_bench.cpp
@@ -135,8 +135,8 @@ static void BM_EventRecord_MT(benchmark::State &state) {
     record_events(events, stream);
   }
 
-  if (state.thread_index == 0)
-    state.SetItemsProcessed(state.iterations() * events_size * state.threads);
+  if (state.thread_index() == 0)
+    state.SetItemsProcessed(state.iterations() * events_size * state.threads());
 
   destroy_events(events);
 }


### PR DESCRIPTION
- The master branch was renamed to main and the API changed slightly. Using a specific version tag will prevent future failures.